### PR TITLE
Update rewindable default value in Builder.php

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -76,7 +76,7 @@ class Builder
      */
     private bool $readOnly = false;
 
-    private bool $rewindable = true;
+    private bool $rewindable = false;
 
     /**
      * The Collection instance.
@@ -1394,7 +1394,7 @@ class Builder
         return $this;
     }
 
-    public function setRewindable(bool $rewindable = true): self
+    public function setRewindable(bool $rewindable = false): self
     {
         $this->rewindable = $rewindable;
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Why not disable result caching by default? I think that the current behavior is not intuitive, as it causes additional memory usage, and this feature is likely unnecessary in most situations.
